### PR TITLE
Add hrefs starting with 'mailto:' and 'tel:' to the list of hrefs that should not be loaded by the reverse proxy.

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,11 +2,14 @@ import {getAbsoluteURL} from 'utils/url';
 
 document.addEventListener('click', (e) => {
     if (frameElement && document.activeElement && (document.activeElement as HTMLAnchorElement).href) {
-        // hrefs that start with one of the following aren't supposed to be followed by the browser, but rather, execute context-dependent actions within the loaded webpage.
+         // Firefox puts an incorrect href into element.href which doesn't correspondent to the attribute href and isn't relative to main url.
         const href = document.activeElement.getAttribute('href');
+        // hrefs that start with one of the following aren't supposed to be followed by the browser, 
+        // but rather, execute context-dependent actions within the loaded webpage.
         if (href.startsWith('javascript:') || href.startsWith('mailto:') || href.startsWith('tel:')) {
             return;
         }
+        
         e.preventDefault();
         const topHref = window.top.location.href;
         const absoluteURL = getAbsoluteURL(topHref.substring(topHref.indexOf('url=') + 4), href);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,9 +2,9 @@ import {getAbsoluteURL} from 'utils/url';
 
 document.addEventListener('click', (e) => {
     if (frameElement && document.activeElement && (document.activeElement as HTMLAnchorElement).href) {
-        // Firefox puts an incorrect href into element.href which doesn't correspondent to the attribute href and isn't relative to main url.
+        // hrefs that start with one of the following aren't supposed to be followed by the browser, but rather, execute context-dependent actions within the loaded webpage.
         const href = document.activeElement.getAttribute('href');
-        if (href.startsWith('javascript:')) {
+        if (href.startsWith('javascript:') || href.startsWith('mailto:') || href.startsWith('tel:')) {
             return;
         }
         e.preventDefault();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,7 +2,7 @@ import {getAbsoluteURL} from 'utils/url';
 
 document.addEventListener('click', (e) => {
     if (frameElement && document.activeElement && (document.activeElement as HTMLAnchorElement).href) {
-         // Firefox puts an incorrect href into element.href which doesn't correspondent to the attribute href and isn't relative to main url.
+        // Firefox puts an incorrect href into element.href which doesn't correspondent to the attribute href and isn't relative to main url.
         const href = document.activeElement.getAttribute('href');
         // hrefs that start with one of the following aren't supposed to be followed by the browser, 
         // but rather, execute context-dependent actions within the loaded webpage.


### PR DESCRIPTION
See [this comment](https://github.com/Gusted/darkreader-web/issues/8#issuecomment-787216256)